### PR TITLE
removed redundant code on minus icon

### DIFF
--- a/src/css/_mixins.scss
+++ b/src/css/_mixins.scss
@@ -43,10 +43,6 @@
     display: block;
     position: absolute;
     margin-top: 4px;
-    @include mq(leftCol) {
-      left: 0;
-      right: 10px;
-    }
   }
 
 }


### PR DESCRIPTION
On expanding the stand first, the minus icon was sticking out to the left on leftCol and above. It's not now.

![gif-keyboard-10451590677715409942](https://cloud.githubusercontent.com/assets/2067172/17898957/8be89f12-6951-11e6-83d9-e5a8b646a305.gif)
