### PR TITLE
chapters now align top

### DIFF
--- a/src/css/_docs.scss
+++ b/src/css/_docs.scss
@@ -407,6 +407,7 @@
   }
   li {
     cursor: pointer;
+    vertical-align: top;
     display: inline-block;
     @include fs-textSans(4);
     white-space: pre-wrap;


### PR DESCRIPTION
Charlie put in a chapter that was over 2 lines and made me go in and fix the alignment.
Another PR would be to auto set the height and add that space to the expand video, so the chapters don't get cut off.

![image](https://cloud.githubusercontent.com/assets/2067172/18168877/b5cd2870-704f-11e6-88a1-b31fc14c46c0.png)
