### PR TITLE
pad out duration to 2 digits

### DIFF
--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -121,7 +121,12 @@ function getYouTubeVideoDuration(videoId, callback){
         success: (resp) => {
             let duration =  resp.items[0].contentDetails.duration;
             let re = /PT(\d+)M(\d+)S/;
-            callback(duration.replace(re,'$1:$2'));
+            callback(duration.replace(re,function(match, p1, p2) {
+                function numberToTwoDigits(number) {
+                    return (number < 10 ? '0' : '') + number;
+                }
+                return `${p1}:${numberToTwoDigits(p2)}`;
+            }));
         }
     });
 }


### PR DESCRIPTION
e.g. `1:1` changes to `1:01`

CC @akash1810 