### PR TITLE
simplify share options

### DIFF
--- a/src/js/lib/share.js
+++ b/src/js/lib/share.js
@@ -1,18 +1,16 @@
 const twitterBaseUrl = 'https://twitter.com/intent/tweet?text=';
-const facebookBaseUrl = 'https://www.facebook.com/dialog/feed?display=popup&app_id=741666719251986&redirect_uri=http://www.theguardian.com&link=';
+const facebookBaseUrl = 'https://www.facebook.com/dialog/share?app_id=180444840287&href=';
 const googleBaseUrl = 'https://plus.google.com/share?url=';
 
-export default function share(title, shareURL, fbImg, twImg, hashTag) {
-    var twImgText = twImg ? ` ${twImg.trim()} ` : ' ';
-    var fbImgQry = fbImg ? `&picture=${encodeURIComponent(fbImg)}` : '';
+export default function share(title, shareURL) {
     return function (network, extra='') {
-        var twitterMessage = `${extra}${title}${twImgText}${hashTag}`;
+        var twitterMessage = `${extra}${title}`;
         var shareWindow;
 
         if (network === 'twitter') {
             shareWindow = twitterBaseUrl + encodeURIComponent(twitterMessage + ' ') + shareURL;
         } else if (network === 'facebook') {
-            shareWindow = facebookBaseUrl + shareURL + fbImgQry;
+            shareWindow = facebookBaseUrl + shareURL;
         } else if (network === 'email') {
             shareWindow = 'mailto:?subject=' + encodeURIComponent(title) + '&body=' + shareURL;
         } else if (network === 'google') {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,17 +4,20 @@ import share from './lib/share';
 import sheetToDOM from './lib/sheettodom';
 import emailsignupURL from './lib/emailsignupURL';
 
-var shareFn = share('Interactive title', 'http://gu.com/p/URL', '#Interactive');
 
 export function init(el, context, config) {
     const builder = document.createElement('div');
     builder.innerHTML = mainHTML.replace(/%assetPath%/g, config.assetPath);
 
     sheetToDOM(config.sheetId, config.sheetName, builder, function callback(resp){
+        var shareFn = share(resp.sheets[config.sheetName][0].title, window.location);
+
         [].slice.apply(builder.querySelectorAll('.interactive-share')).forEach(shareEl => {
             var network = shareEl.getAttribute('data-network');
             shareEl.addEventListener('click', () => shareFn(network));
         });
+
+
         const youTubeId = resp.sheets[config.sheetName][0].youTubeId;
         const youTubeTrailerId = resp.sheets[config.sheetName][0].youTubeTrailerId;
         const chapters = resp.sheets[config.sheetChapter];


### PR DESCRIPTION
This attempts to simplify the share options, to require minimal configuration and be closer to the current behaviour of Frontend.
* Use OG markup for Facebook 
* Use title from config for Twitter

CC @akash1810 