### PR TITLE
Add top border back to inactive chapters

### DIFF
--- a/src/css/_docs.scss
+++ b/src/css/_docs.scss
@@ -435,6 +435,7 @@
     font-size: 15px;
     line-height: 17px;
     position: relative;
+    border-top: 1px solid #333;
     &:before {
       display: block;
       line-height: 14px;
@@ -450,7 +451,7 @@
   }
   &-active {
     //Apologies but can only make work with !important
-    border-top: 1px solid $c-white !important;
+    border-top: 1px solid $c-grey-lightest !important;
     opacity: 1;
     transition: all 360ms;
   }


### PR DESCRIPTION
This adds the top border back to inactive chapters, so the text doesn't jump down 1px when they become active.