### PR TITLE
Playback tracking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,8 @@
         "linebreak-style":  ["error", "unix"],
         "quotes":           ["error", "single"],
         "semi":             ["error", "always"]
+    },
+    "globals": {
+      "require": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "jspm": {
     "configFile": "src/js/config.js",
     "dependencies": {
+      "events": "github:jspm/nodelibs-events@^0.1.1",
       "guardian/iframe-messenger": "github:guardian/iframe-messenger@master",
       "json": "github:systemjs/plugin-json@^0.1.0",
       "reqwest": "github:ded/reqwest@^1.1.5",

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -22,6 +22,7 @@ System.config({
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.6",
+    "events": "github:jspm/nodelibs-events@0.1.1",
     "guardian/iframe-messenger": "github:guardian/iframe-messenger@master",
     "json": "github:systemjs/plugin-json@0.1.2",
     "reqwest": "github:ded/reqwest@1.1.5",
@@ -33,6 +34,9 @@ System.config({
     },
     "github:jspm/nodelibs-buffer@0.1.0": {
       "buffer": "npm:buffer@3.6.0"
+    },
+    "github:jspm/nodelibs-events@0.1.1": {
+      "events": "npm:events@1.0.2"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"

--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -6,10 +6,32 @@ import events from 'events';
 export function pimpYouTubePlayer(videoId, node, height, width, chapters) {
 
     const emitter = new events.EventEmitter();
-    emitter.once('25', () => {console.log("25")});
-    emitter.once('50', () => {console.log("50")});
-    emitter.once('75', () => {console.log("75")});
-    emitter.once('100', () => {console.log("100")});
+
+    function initEvents() {
+
+        const eventList = ['play', '25', '50', '75', 'end'];
+
+        for (const e of eventList) {
+            emitter.once(e, () => {
+                ophanRecord(e)
+            })
+        }
+
+        function ophanRecord(event) {
+            var ophanPath = 'ophan/ng';
+            require([ophanPath], function (ophan) {
+                var eventObject = {};
+                eventObject['video'] = {
+                    id: 'gu-video-youtube-'+videoId,
+                    eventType: 'video:content:'+event
+                };
+                ophan.record(eventObject);
+            });
+
+        }
+    }
+
+    initEvents();
 
     youTubeIframe.init(function() {
         //preload youtube iframe API
@@ -83,10 +105,22 @@ export function pimpYouTubePlayer(videoId, node, height, width, chapters) {
     function sendPercentageCompleteEvents(youTubePlayer, playerTotalTime, emitter) {
         const quartile = playerTotalTime / 4;
 
-        if (youTubePlayer.getCurrentTime() > quartile)
+        if (youTubePlayer.getCurrentTime() > quartile) {
             emitter.emit('25');
         }
 
+        if (youTubePlayer.getCurrentTime() > quartile*2) {
+            emitter.emit('50');
+        }
+        if (youTubePlayer.getCurrentTime() > quartile*3) {
+            emitter.emit('75');
+        }
+
+        if (youTubePlayer.getCurrentTime() > quartile*4) {
+            emitter.emit('end');
+        }
+
+    }
 }
 
 function performPlayActions(videoExpand, youTubePlayer, posterHide) {
@@ -109,6 +143,7 @@ function performPlayActions(videoExpand, youTubePlayer, posterHide) {
 
     scrollTo(document.body, 0, 300);
     youTubePlayer.playVideo();
+    emitter.emit('play');
     posterHide.classList.add('docs__poster--hide');
 }
 

--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -14,16 +14,15 @@ function pimpYouTubePlayer(videoId, node, height, width, chapters) {
         eventList.forEach(e => emitter.once(e, () => ophanRecord(e)));
 
         function ophanRecord(event) {
-            var ophanPath = 'ophan/ng';
-            require([ophanPath], function (ophan) {
-                var eventObject = {};
-                eventObject.video = {
-                    id: 'gu-video-youtube-'+videoId,
-                    eventType: 'video:content:'+event
+            require(['ophan/ng'], function (ophan) {
+                var eventObject = {
+                    video: {
+                        id: 'gu-video-youtube-' + videoId,
+                        eventType: 'video:content:' + event
+                    }
                 };
                 ophan.record(eventObject);
             });
-
         }
     }
 
@@ -47,8 +46,8 @@ function pimpYouTubePlayer(videoId, node, height, width, chapters) {
 
                             const playerTotalTime = youTubePlayer.getDuration();
                             playTimer = setInterval(function() {
-                            chapterTimer(youTubePlayer, playerTotalTime);
-                            sendPercentageCompleteEvents(youTubePlayer, playerTotalTime);
+                                chapterTimer(youTubePlayer, playerTotalTime);
+                                sendPercentageCompleteEvents(youTubePlayer, playerTotalTime);
                             }, 1000);
                         } else {
                             clearTimeout(playTimer);

--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -100,13 +100,22 @@ function pimpYouTubePlayer(videoId, node, height, width, chapters) {
     function sendPercentageCompleteEvents(youTubePlayer, playerTotalTime) {
         const quartile = playerTotalTime / 4;
 
-        let playbackEvents = new Map()
-        .set('25', quartile)
-        .set('50', quartile*2)
-        .set('75', quartile*3)
-        .set('end', quartile*4);
+        const playbackEvents =
+        {
+            '25': quartile,
+            '50': quartile * 2,
+            '75': quartile * 3,
+            'end': playerTotalTime
+        };
 
-        for (let [eventName, eventTrigger] of playbackEvents.entries()) {
+
+        function* entries(obj) {
+            for (let key of Object.keys(obj)) {
+                yield [key, obj[key]];
+            }
+        }
+
+        for (let [eventName, eventTrigger] of entries(playbackEvents)) {
             if (youTubePlayer.getCurrentTime() > eventTrigger) {
                 emitter.emit(eventName);
             }

--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -108,16 +108,9 @@ function pimpYouTubePlayer(videoId, node, height, width, chapters) {
             'end': playerTotalTime
         };
 
-
-        function* entries(obj) {
-            for (let key of Object.keys(obj)) {
-                yield [key, obj[key]];
-            }
-        }
-
-        for (let [eventName, eventTrigger] of entries(playbackEvents)) {
-            if (youTubePlayer.getCurrentTime() > eventTrigger) {
-                emitter.emit(eventName);
+        for (let prop in playbackEvents) {
+            if (youTubePlayer.getCurrentTime() > playbackEvents[prop]) {
+                emitter.emit(prop);
             }
         }
     }

--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -3,9 +3,9 @@ import youTubeIframe from 'youtube-iframe-player';
 import reqwest from 'reqwest';
 import events from 'events';
 
-export function pimpYouTubePlayer(videoId, node, height, width, chapters) {
+const emitter = new events.EventEmitter();
 
-    const emitter = new events.EventEmitter();
+function pimpYouTubePlayer(videoId, node, height, width, chapters) {
 
     function initEvents() {
 
@@ -52,7 +52,7 @@ export function pimpYouTubePlayer(videoId, node, height, width, chapters) {
                             const playerTotalTime = youTubePlayer.getDuration();
                             playTimer = setInterval(function() {
                             chapterTimer(youTubePlayer, playerTotalTime);
-                            sendPercentageCompleteEvents(youTubePlayer, playerTotalTime, emitter);
+                            sendPercentageCompleteEvents(youTubePlayer, playerTotalTime);
                             }, 1000);
                         } else {
                             clearTimeout(playTimer);
@@ -102,24 +102,20 @@ export function pimpYouTubePlayer(videoId, node, height, width, chapters) {
         }
     }
 
-    function sendPercentageCompleteEvents(youTubePlayer, playerTotalTime, emitter) {
+    function sendPercentageCompleteEvents(youTubePlayer, playerTotalTime) {
         const quartile = playerTotalTime / 4;
 
-        if (youTubePlayer.getCurrentTime() > quartile) {
-            emitter.emit('25');
-        }
+        let playbackEvents = new Map()
+        .set('25', quartile)
+        .set('50', quartile*2)
+        .set('75', quartile*3)
+        .set('end', quartile*4);
 
-        if (youTubePlayer.getCurrentTime() > quartile*2) {
-            emitter.emit('50');
+        for (let [eventName, eventTrigger] of playbackEvents.entries()) {
+            if (youTubePlayer.getCurrentTime() > eventTrigger) {
+                emitter.emit(eventName);
+            }
         }
-        if (youTubePlayer.getCurrentTime() > quartile*3) {
-            emitter.emit('75');
-        }
-
-        if (youTubePlayer.getCurrentTime() > quartile*4) {
-            emitter.emit('end');
-        }
-
     }
 }
 

--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -11,17 +11,13 @@ function pimpYouTubePlayer(videoId, node, height, width, chapters) {
 
         const eventList = ['play', '25', '50', '75', 'end'];
 
-        for (const e of eventList) {
-            emitter.once(e, () => {
-                ophanRecord(e)
-            })
-        }
+        eventList.forEach(e => emitter.once(e, () => ophanRecord(e)));
 
         function ophanRecord(event) {
             var ophanPath = 'ophan/ng';
             require([ophanPath], function (ophan) {
                 var eventObject = {};
-                eventObject['video'] = {
+                eventObject.video = {
                     id: 'gu-video-youtube-'+videoId,
                     eventType: 'video:content:'+event
                 };


### PR DESCRIPTION
Mirror most playback events currently sent by VideoJS, namely:

* `content:video:play`
* `content:video:25`
* `content:video:50`
* `content:video:75`
* `content:video:end`

Note: I don't expect this to appear in Ophan frontend but it should be queryable in the data lake.

CC @akash1810 @emma-p