### PR TITLE
do not set poster image in css

### DIFF
--- a/src/css/_youtube.scss
+++ b/src/css/_youtube.scss
@@ -62,7 +62,6 @@
   &--image {
     position: absolute;
     width: 100%;
-    background-image: url('//media.guim.co.uk/b780d238701947d61947932662b06d5a84e3f145/0_196_2500_1500/2500.jpg');
     height: 100%;
     background-position: center center;
     background-size: cover;


### PR DESCRIPTION
We're already setting the `background-image` [in js](https://github.com/guardian/docs-interactive-template/blob/aa-poster-image/src/js/main.js#L110) with a value from the sheet. Setting it via css just overrides this and doesn't make it dynamic, which is bad.