### PR TITLE
chapter refactor

### DIFF
--- a/src/js/lib/dom.js
+++ b/src/js/lib/dom.js
@@ -1,11 +1,13 @@
 function setAttributes(el, attrs) {
-    Object.keys(attrs).forEach(attr => {
-        if (attr === 'style') {
-            Object.keys(attrs[attr]).forEach(style => el.style[style] = attrs[attr][style]);
-        } else {
-            el.setAttribute(attr, attrs[attr]);
-        }
-    });
+    Object.keys(attrs).forEach(attr => el.setAttribute(attr, attrs[attr]));
 }
 
-export default setAttributes;
+function setData(el, data) {
+    Object.keys(data).forEach(key => el.dataset[key] = data[key]);
+}
+
+function setStyles(el, styles) {
+    Object.keys(styles).forEach(style => el.style[style] = styles[style]);
+}
+
+export {setAttributes, setData, setStyles};


### PR DESCRIPTION
branched off of https://github.com/guardian/docs-interactive-template/pull/72 (that needs to be merged in before this gets reviewed)

- `initChapters` function in main.js to encapsulate the chapter operations.
- keep `.filter` operation clean; move percentage progress calculation outside of `.filter`. Also removes a dodgy `let`.