### PR TITLE
explicitly add grunt-aws dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bower": "^1.7.7",
     "eslint": "^3.3.1",
     "grunt": "^0.4.5",
+    "grunt-aws": "^0.6.2",
     "grunt-aws-s3": "^0.14.5",
     "grunt-cli": "^1.1.0",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
to avoid the warnings when trying to deploy