### PR TITLE
bind click handler early

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,5 @@
 import mainHTML from './text/main.html!text';
-import {pimpYouTubePlayer, getYouTubeVideoDuration} from './lib/youtube';
+import {PimpedYouTubePlayer, getYouTubeVideoDuration} from './lib/youtube';
 import share from './lib/share';
 import sheetToDomInnerHtml from './lib/sheettodom';
 import emailsignupURL from './lib/emailsignupURL';
@@ -130,7 +130,10 @@ export function init(el, context, config) {
             src: emailsignupURL(config.emailListId)
         });
 
-        pimpYouTubePlayer(youTubeId, builder, '100%', '100%', chapters);
+        builder.querySelector('.docs__poster--loader').addEventListener('click', function() {
+            const player = new PimpedYouTubePlayer(youTubeId, builder, '100%', '100%', chapters);
+            player.play();
+        });
 
         setStyles(builder.querySelector('.docs__poster--image'), {
             'background-image': `url('${resp.sheets[config.sheetName][0].backgroundImageUrl}')`


### PR DESCRIPTION
Currently, the click event handler for `.docs_poster--loader` is attached once the YouTube player is ready. This means interaction to the element is blocked until the js is downloaded, so early clicks are lost.

This changes the behaviour. Now, the click event handler is bound early and it invokes the download of the YouTube js. This means you can interact with the `.docs_poster--loader` element as soon as the page loads, rather than having to wait until the js is loaded.