### PR TITLE
fix chapter 1 click handler

### DIFF
--- a/src/js/lib/youtube.js
+++ b/src/js/lib/youtube.js
@@ -19,7 +19,7 @@ class PimpedYouTubePlayer {
         scrollTo(document.body, 0, 300);
         self.el.querySelector('.docs__poster--loader').classList.add('docs__poster--hide');
 
-        if (seconds) {
+        if (seconds !== undefined) {
             self.player.seekTo(seconds, true);
         }
 


### PR DESCRIPTION
The first chapter li has a start time of 0. JavaScript is fun: `if (0)` is false...

```js
const seconds = 0;

if (seconds) {
    console.log('You will never get here!');
}

```

Checking if `seconds` is not `undefined` is better.