### PR TITLE
crude polyfill for object.assign

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,7 @@
   "esversion": 6,
   "newcap": true,
   "quotmark": "single",
-  "maxdepth": 3,
+  "maxdepth": 5,
   "browser": true,
   "mocha": false,
   "globals": {}

--- a/src/js/boot.js.tpl
+++ b/src/js/boot.js.tpl
@@ -24,6 +24,31 @@ define([], function() {
             };
 
             if (config) {
+                if (typeof Object.assign != 'function') {
+                  (function () {
+                    Object.assign = function (target) {
+                      'use strict';
+                      // We must check against these specific cases.
+                      if (target === undefined || target === null) {
+                        throw new TypeError('Cannot convert undefined or null to object');
+                      }
+
+                      var output = Object(target);
+                      for (var index = 1; index < arguments.length; index++) {
+                        var source = arguments[index];
+                        if (source !== undefined && source !== null) {
+                          for (var nextKey in source) {
+                            if (source.hasOwnProperty(nextKey)) {
+                              output[nextKey] = source[nextKey];
+                            }
+                          }
+                        }
+                      }
+                      return output;
+                    };
+                  })();
+                }
+            
                 Object.assign(interactiveConfig, config);
             }
 

--- a/src/js/lib/tracking.js
+++ b/src/js/lib/tracking.js
@@ -11,6 +11,8 @@ class Tracker {
     }
 
     buildGoogleAnalyticsEventObject(event) {
+        //TODO replace this polyfill with the babel plugin
+        //see: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
         if (typeof Object.assign != 'function') {
             (function () {
                 Object.assign = function (target) {

--- a/src/js/lib/tracking.js
+++ b/src/js/lib/tracking.js
@@ -11,6 +11,31 @@ class Tracker {
     }
 
     buildGoogleAnalyticsEventObject(event) {
+        if (typeof Object.assign != 'function') {
+            (function () {
+                Object.assign = function (target) {
+                    'use strict';
+                    // We must check against these specific cases.
+                    if (target === undefined || target === null) {
+                        throw new TypeError('Cannot convert undefined or null to object');
+                    }
+
+                    var output = Object(target);
+                    for (var index = 1; index < arguments.length; index++) {
+                        var source = arguments[index];
+                        if (source !== undefined && source !== null) {
+                            for (var nextKey in source) {
+                                if (source.hasOwnProperty(nextKey)) {
+                                    output[nextKey] = source[nextKey];
+                                }
+                            }
+                        }
+                    }
+                    return output;
+                };
+            })();
+        }
+
         // copy `baseEventObject`
         const eventObject = Object.assign({}, this.googleAnalyticsProperties.baseEventObject);
         eventObject[this.googleAnalyticsProperties.metricMap[event]] = 1;


### PR DESCRIPTION
couldn't get babel plugin working, so just using the polyfill provided by mdn (https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill)

will replace once I've got the babel plugin working