### PR TITLE
Revert "loading... whilst awaiting youtube iframe"

### DIFF
--- a/src/css/_youtube.scss
+++ b/src/css/_youtube.scss
@@ -26,16 +26,6 @@
     &--playing {
       // 103px is the header height (48) + chapters height (55)
       height: calc(100vh - 103px);
-      &:after {
-        content: 'Loading...';
-        display: inline-block;
-        width: 100%;
-        height: calc(100vh - 103px);
-        line-height: calc(100vh - 103px);
-        font-size: 30px;
-        text-align: center;
-        color: $c-grey-lightest;
-      }
     }
 
     position: relative;


### PR DESCRIPTION
Reverts guardian/docs-interactive-template#89

its broken in firefox as it doesn't disappear:

<img width="377" alt="screen shot 2016-10-18 at 09 13 28" src="https://cloud.githubusercontent.com/assets/836140/19469426/2f0ace80-9513-11e6-8fa6-285b43164477.png">
