### PR TITLE
fix tracking

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -137,7 +137,7 @@ export function init(el, context, config) {
         const shouldAutoPlay = autoplayReferrers.find(ref => ref.test(document.referrer));
 
         builder.querySelector('.docs__poster--loader').addEventListener('click', function() {
-            const player = new PimpedYouTubePlayer(youTubeId, builder, '100%', '100%', config);
+            const player = new PimpedYouTubePlayer(youTubeId, builder, '100%', '100%', chaptersResp, config);
             player.play();
         });
 
@@ -147,7 +147,7 @@ export function init(el, context, config) {
             builder.querySelector('.docs__poster--title').classList.add('will-autoplay');
             autoplayTimeout = setTimeout(()=> {
                 builder.querySelector('.docs__poster--title').classList.remove('will-autoplay');
-                const player = new PimpedYouTubePlayer(youTubeId, builder, '100%', '100%', config);
+                const player = new PimpedYouTubePlayer(youTubeId, builder, '100%', '100%', chaptersResp, config);
                 player.play();
             }, 8000);
         }


### PR DESCRIPTION
missing an argument in the [constructor](https://github.com/guardian/docs-interactive-template/blob/aa-fix-tracking/src/js/lib/youtube.js#L41) caused bad things to happen

currently on https://www.theguardian.com/world/ng-interactive/2017/jan/06/radical-brownies-berets-badges-and-social-justice-video

<img width="542" alt="screen shot 2017-02-09 at 23 24 48" src="https://cloud.githubusercontent.com/assets/836140/22807469/04eaa6c8-ef1f-11e6-9be8-41eef33deade.png">
