### PR TITLE
use PROD URL for email signup in apps

### DIFF
--- a/src/js/lib/emailsignupURL.js
+++ b/src/js/lib/emailsignupURL.js
@@ -1,3 +1,4 @@
 export default function emailsignupURL(listId) {
-    return window.location.origin === 'https://www.theguardian.com' ? `https://www.theguardian.com/email/form/plaindark/${listId}` : `https://m.code.dev-theguardian.com/email/form/plaindark/${listId}`;
+    const isApp = window.location.protocol === "file:";
+    return window.location.origin === 'https://www.theguardian.com' || isApp ? `https://www.theguardian.com/email/form/plaindark/${listId}` : `https://m.code.dev-theguardian.com/email/form/plaindark/${listId}`;
 }

--- a/src/js/lib/emailsignupURL.js
+++ b/src/js/lib/emailsignupURL.js
@@ -1,4 +1,4 @@
 export default function emailsignupURL(listId) {
-    const isApp = window.location.protocol === "file:";
+    const isApp = window.location.protocol === 'file:';
     return window.location.origin === 'https://www.theguardian.com' || isApp ? `https://www.theguardian.com/email/form/plaindark/${listId}` : `https://m.code.dev-theguardian.com/email/form/plaindark/${listId}`;
 }


### PR DESCRIPTION
Previously the apps were getting the CODE sign-up URL as they don't have the same `window.location.origin` as web. 