### PR TITLE
add interactive prefix to ophan media events

### DIFF
--- a/src/js/lib/tracking.js
+++ b/src/js/lib/tracking.js
@@ -4,7 +4,7 @@ class Tracker {
     buildOphanEventObject(event) {
         return {
             video: {
-                id: this.trackingId,
+                id: `interactive-${this.trackingId}`,
                 eventType: `video:content:${event}`
             }
         };


### PR DESCRIPTION
This is to provide a hook to allow Ophan to differentiate Atoms from other media events. 
Ideally the thrift definition would allow for a platform value. But without this we only have the `mediaId` to play with.

CC @obrienm 

Example event:

<img width="597" alt="screen shot 2017-03-13 at 15 56 45" src="https://cloud.githubusercontent.com/assets/1764158/23862863/0f96563a-0806-11e7-9ddf-9efb60a75e4e.png">