### PR TITLE
adds support for configuring supported by in the sheet

### DIFF
--- a/src/js/lib/docs-coming-soon.js
+++ b/src/js/lib/docs-coming-soon.js
@@ -1,0 +1,8 @@
+class DocsComingSoon {
+    static render({node}) {
+        const text = 'Next up from the groundbreaking Guardian Bertha documentary partnership';
+        node.querySelector('.coming-soon__container-title .details').innerText = text;
+    }
+}
+
+export default DocsComingSoon;

--- a/src/js/lib/docs-supporter.js
+++ b/src/js/lib/docs-supporter.js
@@ -1,0 +1,65 @@
+import {stringToNode} from './dom';
+
+class DocsSupporter {
+    static get defaults() {
+        return {
+            badgeUrl: 'https://uploads.guim.co.uk/2017/01/11/bertha-foundation-logo-grey.png',
+            siteUrl: 'http://www.berthafoundation.org/',
+            info: `
+                <p class="docs--about-headline">About the Guardian Bertha documentary partnership</p>
+                <p>The Guardian is partnering with Bertha Foundation to tell international documentary film stories with global impact.</p>
+                <p><a href='http://berthafoundation.org/'>Bertha Foundation</a> support activists, storytellers and lawyers who are working to bring about social and economic justice, and human rights for all.</p>
+                <p>The Guardian and Bertha Foundation are commissioning a series of 12 short documentary films from independent filmmakers. The series covers global stories, with a focus on films that have the ability to advance the contemporary issues they address, and and raise awareness of people and movements who are catalysts for change.</p>
+                <p>These documentaries help the Guardian audience to understand the world in creative, entertaining and surprising ways designed for a wide online audience. All documentaries are editorially independent and follow GNM's published editorial code.</p>
+                <p>This unique collaboration involves the Guardian and Bertha Foundation engaging a network of film-makers with embedded access to, and deep knowledge of, the communities in which they are filming. The Guardian are delighted to be working with Bertha Foundation who have a track record of supporting documentary makers that make a significant difference in the world.</p>
+                <p class="docs--about-legal">Unless otherwise stated, all statements and materials in these documentaries reflect the views of the individual documentary makers and not those of Bertha Foundation or the Guardian.</p>
+            `
+        };
+    }
+
+    constructor({node, badgeUrl, siteUrl, info}) {
+        this.badgeUrl = badgeUrl || DocsSupporter.defaults.badgeUrl;
+        this.siteUrl = siteUrl || DocsSupporter.defaults.siteUrl;
+        this.info = info || DocsSupporter.defaults.info;
+
+        const badgeNode = this.badgeNode();
+        const infoNode = this.infoNode();
+        const infoWrapper = node.querySelector('.docs--about-wrapper');
+
+        const badgePlaceholder = node.querySelector('.meta__supporter');
+        badgePlaceholder.appendChild(badgeNode);
+
+        const infoPlaceholder = node.querySelector('.docs--about-body');
+        infoPlaceholder.appendChild(infoNode);
+
+        // clicking on modal text does nothing
+        node.querySelector('.docs--about-body').addEventListener('click', (e) => e.stopPropagation());
+
+        // close modal
+        infoWrapper.addEventListener('click', () => {
+            infoWrapper.classList.remove('docs--show-about');
+        });
+
+        // open modal
+        badgeNode.querySelector('.supporter-info').addEventListener('click', () => {
+            infoWrapper.classList.add('docs--show-about');
+        });
+    }
+
+    badgeNode() {
+        const htmlString = `
+            <div class='supporter-info' id='show-about-these-films'>Supported by</div>
+            <a class='supporter-logo' href="${this.siteUrl}" target="_blank">
+                <img src='${this.badgeUrl}'>
+            </a>
+        `;
+
+        return stringToNode(htmlString);
+    }
+
+    infoNode() {
+        return stringToNode(this.info);
+    }
+}
+
+export default DocsSupporter;

--- a/src/js/lib/dom.js
+++ b/src/js/lib/dom.js
@@ -22,4 +22,10 @@ function scrollTo(element, to, duration) {
     }, 10);
 }
 
-export {setAttributes, setData, setStyles, scrollTo};
+function stringToNode(htmlString) {
+    const el = document.createElement('div');
+    el.innerHTML = htmlString;
+    return el;
+}
+
+export {setAttributes, setData, setStyles, scrollTo, stringToNode};

--- a/src/js/text/main.html
+++ b/src/js/text/main.html
@@ -25,15 +25,7 @@
     <div class="docs--about-wrapper">
         <div class="docs--about-overlay">
             <div class="doc-trailer__close"></div>
-            <div class="docs--about-body">
-                <p class="docs--about-headline">About the Guardian Bertha documentary partnership</p>
-                <p>The Guardian is partnering with Bertha Foundation to tell international documentary film stories with global impact.</p>
-                <p><a href='http://berthafoundation.org/'>Bertha Foundation</a> support activists, storytellers and lawyers who are working to bring about social and economic justice, and human rights for all.</p>
-                <p>The Guardian and Bertha Foundation are commissioning a series of 12 short documentary films from independent filmmakers. The series covers global stories, with a focus on films that have the ability to advance the contemporary issues they address, and and raise awareness of people and movements who are catalysts for change.</p>
-                <p>These documentaries help the Guardian audience to understand the world in creative, entertaining and surprising ways designed for a wide online audience. All documentaries are editorially independent and follow GNM's published editorial code.</p>
-                <p>This unique collaboration involves the Guardian and Bertha Foundation engaging a network of film-makers with embedded access to, and deep knowledge of, the communities in which they are filming. The Guardian are delighted to be working with Bertha Foundation who have a track record of supporting documentary makers that make a significant difference in the world.</p>
-                <p class="docs--about-legal">Unless otherwise stated, all statements and materials in these documentaries reflect the views of the individual documentary makers and not those of Bertha Foundation or the Guardian.</p>
-            </div>
+            <div class="docs--about-body"></div>
         </div>
     </div>
 
@@ -54,12 +46,7 @@
                 <button class="interactive-share" data-network="twitter"></button>
                 <button class="interactive-share" data-network="email"></button>
             </div>
-            <div class='meta__supporter'>
-                <div class='supporter-info' id='show-about-these-films'>Supported by</div>
-                <a class='supporter-logo' href="http://www.berthafoundation.org/" target="_blank">
-                    <img src='https://uploads.guim.co.uk/2017/01/11/bertha-foundation-logo-grey.png'>
-                </a>
-            </div>
+            <div class='meta__supporter'></div>
         </div>
     </div>
 
@@ -94,7 +81,7 @@
         <div class='has-curtains'></div>
         <div class='coming-soon__container-title'>
             <div class='title'>coming soon</div>
-            <div class='details'>Next up from the groundbreaking Guardian Bertha documentary partnership</div>
+            <div class='details'></div>
         </div>
         <div class='coming-soon__contents'>
             <div class='coming-soon__poster'>


### PR DESCRIPTION
Reads the following fields from the sheet:
- showSupported: TRUE|FALSE used to determine whether to render the supported by elements
- supportedBadgeUrl: URL url to supported badge image
- supportedSiteUrl: URL url to link to when clicking on supportedBadgeUrl
- supportedInfo: HTML text to show in the supported by modal
- isBertha: TRUE|FALSE used to determine whether to render the sub-heading in the coming soon section

The supported block is now added to the DOM with javascript. Default is to add it. It is not added iff `showSupported === 'FALSE'`.

The other fields have sensible defaults to Bertha values.

When `showSupported === 'FALSE'`:
![image](https://cloud.githubusercontent.com/assets/836140/24629427/dc8bd614-18b0-11e7-9d6b-af08fd48abd9.png)
