### PR TITLE
use headline field as share text

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -64,10 +64,12 @@ export function init(el, context, config) {
     sheetToDomInnerHtml(config.sheetId, sheetName, builder, config.comingSoonSheetName, function callback(resp) {
         const sheetValues = resp.sheets[sheetName][0]; // TODO refactor all instances of `resp.sheets[sheetName][0]` to use this `const`
 
-        var shareFn = share(resp.sheets[sheetName][0].title, window.location);
+        const headline = window.guardian && window.guardian.config.page.headline;
+        const shareText = headline || resp.sheets[sheetName][0].title;
+        const shareFn = share(shareText, window.location);
 
-        [].slice.apply(builder.querySelectorAll('.interactive-share')).forEach(shareEl => {
-            var network = shareEl.getAttribute('data-network');
+        Array.from(builder.querySelectorAll('.interactive-share')).forEach(shareEl => {
+            const network = shareEl.getAttribute('data-network');
             shareEl.addEventListener('click', () => shareFn(network));
         });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -64,7 +64,8 @@ export function init(el, context, config) {
     sheetToDomInnerHtml(config.sheetId, sheetName, builder, config.comingSoonSheetName, function callback(resp) {
         const sheetValues = resp.sheets[sheetName][0]; // TODO refactor all instances of `resp.sheets[sheetName][0]` to use this `const`
 
-        const headline = window.guardian && window.guardian.config.page.headline;
+        //
+        const headline = window.guardian && window.guardian.config && window.guardian.config.page && window.guardian.config.page.headline;
         const shareText = headline || resp.sheets[sheetName][0].title;
         const shareFn = share(shareText, window.location);
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -63,8 +63,7 @@ export function init(el, context, config) {
     const sheetName = sheetNameFromShortId(config.docsArray, window.guardian.config.page.pageId);
     sheetToDomInnerHtml(config.sheetId, sheetName, builder, config.comingSoonSheetName, function callback(resp) {
         const sheetValues = resp.sheets[sheetName][0]; // TODO refactor all instances of `resp.sheets[sheetName][0]` to use this `const`
-
-        //
+        
         const headline = window.guardian && window.guardian.config && window.guardian.config.page && window.guardian.config.page.headline;
         const shareText = headline || resp.sheets[sheetName][0].title;
         const shareFn = share(shareText, window.location);


### PR DESCRIPTION
falls back to sheet title if `window.guardian` doesn't exist for whatever reason