### PR TITLE
refactor doc metadata into a class

### DIFF
--- a/src/js/lib/docs-supporter.js
+++ b/src/js/lib/docs-supporter.js
@@ -1,26 +1,8 @@
 import {stringToNode} from './dom';
 
 class DocsSupporter {
-    static get defaults() {
-        return {
-            badgeUrl: 'https://uploads.guim.co.uk/2017/01/11/bertha-foundation-logo-grey.png',
-            siteUrl: 'http://www.berthafoundation.org/',
-            info: `
-                <p class="docs--about-headline">About the Guardian Bertha documentary partnership</p>
-                <p>The Guardian is partnering with Bertha Foundation to tell international documentary film stories with global impact.</p>
-                <p><a href='http://berthafoundation.org/'>Bertha Foundation</a> support activists, storytellers and lawyers who are working to bring about social and economic justice, and human rights for all.</p>
-                <p>The Guardian and Bertha Foundation are commissioning a series of 12 short documentary films from independent filmmakers. The series covers global stories, with a focus on films that have the ability to advance the contemporary issues they address, and and raise awareness of people and movements who are catalysts for change.</p>
-                <p>These documentaries help the Guardian audience to understand the world in creative, entertaining and surprising ways designed for a wide online audience. All documentaries are editorially independent and follow GNM's published editorial code.</p>
-                <p>This unique collaboration involves the Guardian and Bertha Foundation engaging a network of film-makers with embedded access to, and deep knowledge of, the communities in which they are filming. The Guardian are delighted to be working with Bertha Foundation who have a track record of supporting documentary makers that make a significant difference in the world.</p>
-                <p class="docs--about-legal">Unless otherwise stated, all statements and materials in these documentaries reflect the views of the individual documentary makers and not those of Bertha Foundation or the Guardian.</p>
-            `
-        };
-    }
-
-    constructor({node, badgeUrl, siteUrl, info}) {
-        this.badgeUrl = badgeUrl || DocsSupporter.defaults.badgeUrl;
-        this.siteUrl = siteUrl || DocsSupporter.defaults.siteUrl;
-        this.info = info || DocsSupporter.defaults.info;
+    constructor({node, docData}) {
+        this.docData = docData;
 
         const badgeNode = this.badgeNode();
         const infoNode = this.infoNode();
@@ -49,8 +31,8 @@ class DocsSupporter {
     badgeNode() {
         const htmlString = `
             <div class='supporter-info' id='show-about-these-films'>Supported by</div>
-            <a class='supporter-logo' href="${this.siteUrl}" target="_blank">
-                <img src='${this.badgeUrl}'>
+            <a class='supporter-logo' href="${this.docData.supportedSiteUrl}" target="_blank">
+                <img src='${this.docData.supportedBadgeUrl}'>
             </a>
         `;
 
@@ -58,7 +40,7 @@ class DocsSupporter {
     }
 
     infoNode() {
-        return stringToNode(this.info);
+        return stringToNode(this.docData.supportedInfo);
     }
 }
 

--- a/src/js/lib/sheetData.js
+++ b/src/js/lib/sheetData.js
@@ -1,0 +1,140 @@
+import sheetUrl from './sheetURL';
+import reqwest from 'reqwest';
+
+const DEFAULT_SUPPORTED_DATA = {
+    supportedBadgeUrl: 'https://uploads.guim.co.uk/2017/01/11/bertha-foundation-logo-grey.png',
+    supportedSiteUrl: 'http://www.berthafoundation.org/',
+    supportedInfo: `
+        <p class="docs--about-headline">About the Guardian Bertha documentary partnership</p>
+        <p>The Guardian is partnering with Bertha Foundation to tell international documentary film stories with global impact.</p>
+        <p><a href='http://berthafoundation.org/'>Bertha Foundation</a> support activists, storytellers and lawyers who are working to bring about social and economic justice, and human rights for all.</p>
+        <p>The Guardian and Bertha Foundation are commissioning a series of 12 short documentary films from independent filmmakers. The series covers global stories, with a focus on films that have the ability to advance the contemporary issues they address, and and raise awareness of people and movements who are catalysts for change.</p>
+        <p>These documentaries help the Guardian audience to understand the world in creative, entertaining and surprising ways designed for a wide online audience. All documentaries are editorially independent and follow GNM's published editorial code.</p>
+        <p>This unique collaboration involves the Guardian and Bertha Foundation engaging a network of film-makers with embedded access to, and deep knowledge of, the communities in which they are filming. The Guardian are delighted to be working with Bertha Foundation who have a track record of supporting documentary makers that make a significant difference in the world.</p>
+        <p class="docs--about-legal">Unless otherwise stated, all statements and materials in these documentaries reflect the views of the individual documentary makers and not those of Bertha Foundation or the Guardian.</p>
+    `
+};
+
+class DocumentaryMetadata {
+    constructor({sheetId, docName, comingSoonSheetName}) {
+        this._sheetId = sheetId;
+        this._docName = docName;
+        this._comingSoonSheetName = comingSoonSheetName;
+    }
+
+    getMetadata() {
+        const url = sheetUrl(this._sheetId);
+
+        return new Promise((resolve, reject) => {
+            reqwest({
+                url: url,
+                type: 'json',
+                crossOrigin: true,
+                success: resp => {
+                    const metadata = resp.sheets.documentaries.find(_ => _.docName === this._docName);
+
+                    if (!metadata && window.console) {
+                        // eslint-disable-next-line no-console
+                        console.warn(`Unable to find sheet data for ${this._docName}`);
+                    }
+
+                    // supported columns are optional in the sheet, use defaults if not set
+                    Object.keys(DEFAULT_SUPPORTED_DATA).forEach(supportedKey => {
+                        if (metadata[supportedKey] === ''){
+                            metadata[supportedKey] = DEFAULT_SUPPORTED_DATA[supportedKey];
+                        }
+                    });
+
+                    const chapters = resp.sheets.chapters.filter(_ => _.docName === this._docName);
+                    const comingSoon = resp.sheets[this._comingSoonSheetName];
+
+                    this._docData = Object.assign(
+                        {},
+                        metadata,
+                        {chapters: chapters, comingSoon: comingSoon}
+                    );
+
+                    resolve(this);
+                },
+                error: err => reject(err)
+            });
+        });
+    }
+
+    getField(field) {
+        if (this._docData) {
+            return this._docData[field];
+        }
+    }
+
+    get title () {
+        return this.getField('title');
+    }
+
+    get shortDescription () {
+        return this.getField('shortDecription');
+    }
+
+    get longDescription () {
+        return this.getField('longDescription');
+    }
+
+    get youtubeId () {
+        return this.getField('youTubeId');
+    }
+
+    get credits () {
+        return this.getField('credits');
+    }
+
+    get docDate () {
+        return this.getField('docDate');
+    }
+
+    get backgroundImageUrl () {
+        return this.getField('backgroundImageUrl');
+    }
+
+    get isBertha () {
+        // is a Bertha doc unless explicitly set to `FALSE` in the sheet
+        return this.getField('isBertha') !== 'FALSE';
+    }
+
+    get isSupported () {
+        // is supported unless explicitly set to `FALSE` in the sheet
+        return this.getField('showSupported') !== 'FALSE';
+    }
+
+    get supportedBadgeUrl () {
+        return this.getField('supportedBadgeUrl');
+    }
+
+    get supportedSiteUrl () {
+        return this.getField('supportedSiteUrl');
+    }
+
+    get supportedInfo () {
+        return this.getField('supportedInfo');
+    }
+
+    get chapters () {
+        return this.getField('chapters');
+    }
+
+    get comingSoon () {
+        return this.getField('comingSoon');
+    }
+
+    get comingNext () {
+        return this.comingSoon[0];
+    }
+
+    get onwardJourneyLinks () {
+        return ['One', 'Two', 'Three', 'Four'].reduce((links, i) => {
+            links.push({position: i, jsonUrl: this.getField(`jsonSnap${i}`)});
+            return links;
+        }, []);
+    }
+}
+
+export default DocumentaryMetadata;

--- a/src/js/lib/sheettodom.js
+++ b/src/js/lib/sheettodom.js
@@ -1,37 +1,16 @@
-import sheetUrl from './sheetURL';
-import reqwest from 'reqwest';
 import startsWith from 'lodash.startswith';
 
+export function sheetToDomInnerHtml({el, docData, comingSoonSheetName}) {
+    Array.from(el.querySelectorAll('[data-sheet-attribute]')).forEach(node => {
+        const field = node.getAttribute('data-sheet-attribute');
 
-export function sheetToDomInnerHtml({sheetId, docName, el, comingSoonSheetName}) {
-
-    const sheet = sheetUrl(sheetId);
-
-    return new Promise((resolve, reject) => {
-        reqwest({
-            'url': sheet,
-            'type': 'json',
-            'crossOrigin': true,
-            'success': resp => {
-                //get list of elements with data-sheet-attribute
-                Array.from(el.querySelectorAll('[data-sheet-attribute]')).forEach(node => {
-                    const field = node.getAttribute('data-sheet-attribute');
-
-                    if(startsWith(field, `${comingSoonSheetName}-`)){
-                        node.innerHTML = resp.sheets[comingSoonSheetName][0][field.split(`${comingSoonSheetName}-`)[1]];
-                    }
-                    else {
-                        const docData = resp.sheets.documentaries.find(_ => _.docName === docName);
-                        node.innerHTML = docData[field];
-                    }
-                });
-
-                resolve(resp);
-            },
-            'error': err => reject(err)
-        });
+        if(startsWith(field, `${comingSoonSheetName}-`)){
+            node.innerHTML = docData.comingNext[field.split(`${comingSoonSheetName}-`)[1]];
+        }
+        else {
+            node.innerHTML = docData.getField(field);
+        }
     });
-
 }
 
 export default sheetToDomInnerHtml;


### PR DESCRIPTION
- abstracts away json structure
- use getters to access metadata fields
- defaults data where necessary

Also results in a better failure case; if we can't find any metadata, we `console.log` (if `window.console` is available). We also do not break rendering, instead we render a slightly nicer:

![screen shot 2017-06-28 at 17 44 42](https://user-images.githubusercontent.com/836140/27650704-9e3b78d6-5c2d-11e7-9e4b-868e1be5cc84.jpeg)
