### PR TITLE
update more documentaries link

### DIFF
--- a/src/js/text/main.html
+++ b/src/js/text/main.html
@@ -54,7 +54,7 @@
         <div class="fc-container__inner">
             <div class="fc-container__header js-container__header">
                 <div class="fc-container__header__title">
-                    <a href='/documentaries' tabindex="0">More documentaries</a>
+                    <a href='https://www.theguardian.com/documentaries' tabindex="0">More documentaries</a>
                 </div>
             </div>
             <div class="fc-container--rolled-up-hide fc-container__body fc-show-more--hidden" data-title="more documentaries" data-id="9846ecf9-a5d4-4b07-a1cf-3e77775c69e5">


### PR DESCRIPTION
change the href to a full URI, as relative URLs don't work in the iOS app