### PR TITLE
Use curl if require is not in scope

### DIFF
--- a/src/js/boot.js.tpl
+++ b/src/js/boot.js.tpl
@@ -110,11 +110,17 @@ define([], function() {
             window.setTimeout(function() {
                 addCSS('<%= assetPath %>/main.css');
             }, 10);
-
+            
             // Load JS and init
-            require(['<%= assetPath %>/main.js'], function(main) {
-                main.init(el, context, interactiveConfig, mediator);
-            }, function(err) { console.error('Error loading boot.', err); });
+            if (typeof require !== 'undefined') {
+                require(['<%= assetPath %>/main.js'], function(main) {
+                    main.init(el, context, interactiveConfig, mediator);
+                }, function(err) { console.error('Error loading boot.', err); });
+            } else if (typeof curl !== 'undefined') {
+                curl(['<%= assetPath %>/main.js'], function(main) {
+                    main.init(el, context, interactiveConfig, mediator);
+                }, function(err) { console.error('Error loading boot.', err); });
+            }
         }
     };
 });

--- a/src/js/boot.js.tpl
+++ b/src/js/boot.js.tpl
@@ -110,7 +110,7 @@ define([], function() {
             window.setTimeout(function() {
                 addCSS('<%= assetPath %>/main.css');
             }, 10);
-            
+
             // Load JS and init
             if (typeof require !== 'undefined') {
                 require(['<%= assetPath %>/main.js'], function(main) {


### PR DESCRIPTION
If no require variable is in scope, fallback to use curl if we have it.

Apps no longer have require in the window scope, but do have curl.

This change should hopefully fix the issue on apps and not require releases.