### PR TITLE
Don't invert YouTube poster image in iOS app

### DIFF
--- a/src/css/_youtube.scss
+++ b/src/css/_youtube.scss
@@ -103,6 +103,10 @@
         height: 100%;
         background-position: center center;
         background-size: cover;
+
+        @media (inverted-colors: inverted) {
+            filter: invert(100%);
+        }
     }
     &--gradient-fill {
         position: absolute;


### PR DESCRIPTION
This prevents the YouTube poster image on documentary pages (e.g. [Black Sheep](https://www.theguardian.com/news/ng-interactive/2018/oct/26/black-sheep-the-black-teenager-who-made-friends-with-racists-video)) in the iOS app from being inverted when a user has enabled [Smart Invert](https://support.apple.com/en-gb/HT207025) on their Apple device. 
 
To see the problem, switch on Smart Invert on your device (Settings -> General -> Accessibility -> Display Accommodations -> Invert Colours -> Smart Invert) and open the above documentary link in the Guardian app. 