### PR TITLE
New onward journey links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{jshintrc,js,yml}]
+[*.{jshintrc,yml}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[.jshintrc]
-indent_size = 2
-
-[*.yml]
+[*.{jshintrc,js,yml}]
 indent_size = 2

--- a/cfg/s3.json
+++ b/cfg/s3.json
@@ -1,5 +1,5 @@
 {
-	"bucket": "gdn-cdn",
-	"path": "2017/02/bertha-docs",
-	"domain": "https://interactive.guim.co.uk/"
+    "bucket": "gdn-cdn",
+    "path": "2020/02/documentaries-player",
+    "domain": "https://interactive.guim.co.uk/"
 }

--- a/cfg/s3.json
+++ b/cfg/s3.json
@@ -1,5 +1,5 @@
 {
     "bucket": "gdn-cdn",
-    "path": "2020/02/documentaries-player",
+    "path": "2017/02/bertha-docs",
     "domain": "https://interactive.guim.co.uk/"
 }

--- a/src/css/_continue-watching.scss
+++ b/src/css/_continue-watching.scss
@@ -1,7 +1,4 @@
 #more-documentaries {
-    &.hidden {
-        display: none;
-    }
     .fc-container__inner {
         border-color: #767676;
         .fc-container__header__title {

--- a/src/css/_continue-watching.scss
+++ b/src/css/_continue-watching.scss
@@ -1,4 +1,7 @@
 #more-documentaries {
+    &.hidden {
+        display: none;
+    }
     .fc-container__inner {
         border-color: #767676;
         .fc-container__header__title {

--- a/src/css/_doc-cards.scss
+++ b/src/css/_doc-cards.scss
@@ -1,0 +1,44 @@
+
+.doc-card {
+    position: relative;
+    background-color: #161616;
+    color: #F6F6F6;
+    font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
+    width: 100%;
+
+    font-size: 16px;
+    line-height: 18px;
+    @include mq(mobileLandscape) {
+        font-size: 18px;
+        line-height: 20px;
+    }
+    @include mq(phablet) {
+        font-size: 16px;
+        line-height: 18px;
+    }
+    @include mq(tablet) {
+        font-size: 18px;
+        line-height: 20px;
+    }
+    &__poster {
+        max-width: 100%;
+        display: block;
+        margin-bottom: 6px;
+    }
+    &__description {
+        font-size: inherit;
+        line-height: inherit;
+        font-weight: 500;
+        padding-bottom: 6px;
+        margin: 0;
+    }
+    & &__link {
+        text-indent: -9em;
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -15,3 +15,4 @@
 @import "coming-soon";
 @import "trailer-overlay";
 @import 'should-fade-in';
+@import 'doc-cards';

--- a/src/js/lib/sheetData.js
+++ b/src/js/lib/sheetData.js
@@ -2,9 +2,9 @@ import sheetUrl from './sheetURL';
 import reqwest from 'reqwest';
 
 const DEFAULT_SUPPORTED_DATA = {
-  supportedBadgeUrl: 'https://uploads.guim.co.uk/2017/01/11/bertha-foundation-logo-grey.png',
-  supportedSiteUrl: 'http://www.berthafoundation.org/',
-  supportedInfo: `
+    supportedBadgeUrl: 'https://uploads.guim.co.uk/2017/01/11/bertha-foundation-logo-grey.png',
+    supportedSiteUrl: 'http://www.berthafoundation.org/',
+    supportedInfo: `
         <p class="docs--about-headline">About the Guardian Bertha documentary partnership</p>
         <p>The Guardian is partnering with Bertha Foundation to tell international documentary film stories with global impact.</p>
         <p><a href='http://berthafoundation.org/'>Bertha Foundation</a> support activists, storytellers and lawyers who are working to bring about social and economic justice, and human rights for all.</p>
@@ -16,142 +16,142 @@ const DEFAULT_SUPPORTED_DATA = {
 };
 
 class DocumentaryMetadata {
-  constructor({ sheetId, docName, comingSoonSheetName }) {
-    this._sheetId = sheetId;
-    this._docName = docName;
-    this._comingSoonSheetName = comingSoonSheetName;
-  }
-
-  getMetadata() {
-    const url = sheetUrl(this._sheetId);
-
-    return new Promise((resolve, reject) => {
-      reqwest({
-        url: url,
-        type: 'json',
-        crossOrigin: true,
-        success: resp => {
-          const metadata = resp.sheets.documentaries.find(_ => _.docName === this._docName);
-
-          if (!metadata && window.console) {
-            // eslint-disable-next-line no-console
-            console.warn(`Unable to find sheet data for ${this._docName}`);
-          }
-
-          const linkedDocs = ['1', '2', '3', '4'].map((i) => {
-            const linkedDocName = metadata[`watchNext${i}`];
-            const linkedDocMetadata = resp.sheets.documentaries.find(_ => _.docName === linkedDocName);
-            if (linkedDocName && linkedDocMetadata) {
-              return linkedDocMetadata;
-            } else {
-              return undefined;
-            }
-          }).filter((doc) => {
-            return doc !== undefined;
-          });
-
-          // supported columns are optional in the sheet, use defaults if not set
-          Object.keys(DEFAULT_SUPPORTED_DATA).forEach(supportedKey => {
-            if (metadata[supportedKey] === '') {
-              metadata[supportedKey] = DEFAULT_SUPPORTED_DATA[supportedKey];
-            }
-          });
-
-          const chapters = resp.sheets.chapters.filter(_ => _.docName === this._docName);
-          const comingSoon = resp.sheets[this._comingSoonSheetName];
-
-          this._docData = Object.assign(
-            {},
-            metadata,
-            { linkedDocs: linkedDocs },
-            { chapters: chapters, comingSoon: comingSoon }
-          );
-
-          resolve(this);
-        },
-        error: err => reject(err)
-      });
-    });
-  }
-
-  getField(field) {
-    if (this._docData) {
-      return this._docData[field];
+    constructor({ sheetId, docName, comingSoonSheetName }) {
+        this._sheetId = sheetId;
+        this._docName = docName;
+        this._comingSoonSheetName = comingSoonSheetName;
     }
-  }
 
-  get title() {
-    return this.getField('title');
-  }
+    getMetadata() {
+        const url = sheetUrl(this._sheetId);
 
-  get shortDescription() {
-    return this.getField('shortDecription');
-  }
+        return new Promise((resolve, reject) => {
+            reqwest({
+                url: url,
+                type: 'json',
+                crossOrigin: true,
+                success: resp => {
+                    const metadata = resp.sheets.documentaries.find(_ => _.docName === this._docName);
 
-  get longDescription() {
-    return this.getField('longDescription');
-  }
+                    if (!metadata && window.console) {
+                        // eslint-disable-next-line no-console
+                        console.warn(`Unable to find sheet data for ${this._docName}`);
+                    }
 
-  get youtubeId() {
-    return this.getField('youTubeId');
-  }
+                    const linkedDocs = ['1', '2', '3', '4'].map((i) => {
+                        const linkedDocName = metadata[`watchNext${i}`];
+                        const linkedDocMetadata = resp.sheets.documentaries.find(_ => _.docName === linkedDocName);
+                        if (linkedDocName && linkedDocMetadata) {
+                            return linkedDocMetadata;
+                        } else {
+                            return undefined;
+                        }
+                    }).filter((doc) => {
+                        return doc !== undefined;
+                    });
 
-  get credits() {
-    return this.getField('credits');
-  }
+                    // supported columns are optional in the sheet, use defaults if not set
+                    Object.keys(DEFAULT_SUPPORTED_DATA).forEach(supportedKey => {
+                        if (metadata[supportedKey] === '') {
+                            metadata[supportedKey] = DEFAULT_SUPPORTED_DATA[supportedKey];
+                        }
+                    });
 
-  get docDate() {
-    return this.getField('docDate');
-  }
+                    const chapters = resp.sheets.chapters.filter(_ => _.docName === this._docName);
+                    const comingSoon = resp.sheets[this._comingSoonSheetName];
 
-  get backgroundImageUrl() {
-    return this.getField('backgroundImageUrl');
-  }
+                    this._docData = Object.assign(
+                        {},
+                        metadata,
+                        { linkedDocs: linkedDocs },
+                        { chapters: chapters, comingSoon: comingSoon }
+                    );
 
-  get isBertha() {
-    // is a Bertha doc unless explicitly set to `FALSE` in the sheet
-    return this.getField('isBertha') !== 'FALSE';
-  }
+                    resolve(this);
+                },
+                error: err => reject(err)
+            });
+        });
+    }
 
-  get isSupported() {
-    // is supported unless explicitly set to `FALSE` in the sheet
-    return this.getField('showSupported') !== 'FALSE';
-  }
+    getField(field) {
+        if (this._docData) {
+            return this._docData[field];
+        }
+    }
 
-  get supportedBadgeUrl() {
-    return this.getField('supportedBadgeUrl');
-  }
+    get title() {
+        return this.getField('title');
+    }
 
-  get supportedSiteUrl() {
-    return this.getField('supportedSiteUrl');
-  }
+    get shortDescription() {
+        return this.getField('shortDecription');
+    }
 
-  get supportedInfo() {
-    return this.getField('supportedInfo');
-  }
+    get longDescription() {
+        return this.getField('longDescription');
+    }
 
-  get chapters() {
-    return this.getField('chapters');
-  }
+    get youtubeId() {
+        return this.getField('youTubeId');
+    }
 
-  get comingSoon() {
-    return this.getField('comingSoon');
-  }
+    get credits() {
+        return this.getField('credits');
+    }
 
-  get comingNext() {
-    return this.comingSoon[0];
-  }
+    get docDate() {
+        return this.getField('docDate');
+    }
 
-  get linkedDocs() {
-    return this._docData.linkedDocs;
-  }
+    get backgroundImageUrl() {
+        return this.getField('backgroundImageUrl');
+    }
 
-  get onwardJourneyLinks() {
-    return ['One', 'Two', 'Three', 'Four'].reduce((links, i) => {
-      links.push({ position: i, jsonUrl: this.getField(`jsonSnap${i}`) });
-      return links;
-    }, []);
-  }
+    get isBertha() {
+        // is a Bertha doc unless explicitly set to `FALSE` in the sheet
+        return this.getField('isBertha') !== 'FALSE';
+    }
+
+    get isSupported() {
+        // is supported unless explicitly set to `FALSE` in the sheet
+        return this.getField('showSupported') !== 'FALSE';
+    }
+
+    get supportedBadgeUrl() {
+        return this.getField('supportedBadgeUrl');
+    }
+
+    get supportedSiteUrl() {
+        return this.getField('supportedSiteUrl');
+    }
+
+    get supportedInfo() {
+        return this.getField('supportedInfo');
+    }
+
+    get chapters() {
+        return this.getField('chapters');
+    }
+
+    get comingSoon() {
+        return this.getField('comingSoon');
+    }
+
+    get comingNext() {
+        return this.comingSoon[0];
+    }
+
+    get linkedDocs() {
+        return this._docData.linkedDocs;
+    }
+
+    get onwardJourneyLinks() {
+        return ['One', 'Two', 'Three', 'Four'].reduce((links, i) => {
+            links.push({ position: i, jsonUrl: this.getField(`jsonSnap${i}`) });
+            return links;
+        }, []);
+    }
 }
 
 export default DocumentaryMetadata;

--- a/src/js/lib/sheetData.js
+++ b/src/js/lib/sheetData.js
@@ -38,6 +38,14 @@ class DocumentaryMetadata {
             console.warn(`Unable to find sheet data for ${this._docName}`);
           }
 
+          const linkedDocs = ['1', '2', '3', '4'].map((i) => {
+            const linkedDocName = metadata[`watchNext${i}`];
+            const linkedDocMetadata = resp.sheets.documentaries.find(_ => _.docName === linkedDocName);
+            return linkedDocMetadata;
+          }).filter((doc) => {
+            return doc !== undefined;
+          });
+
           // supported columns are optional in the sheet, use defaults if not set
           Object.keys(DEFAULT_SUPPORTED_DATA).forEach(supportedKey => {
             if (metadata[supportedKey] === '') {
@@ -51,6 +59,7 @@ class DocumentaryMetadata {
           this._docData = Object.assign(
             {},
             metadata,
+            { linkedDocs: linkedDocs },
             { chapters: chapters, comingSoon: comingSoon }
           );
 

--- a/src/js/lib/sheetData.js
+++ b/src/js/lib/sheetData.js
@@ -41,7 +41,11 @@ class DocumentaryMetadata {
           const linkedDocs = ['1', '2', '3', '4'].map((i) => {
             const linkedDocName = metadata[`watchNext${i}`];
             const linkedDocMetadata = resp.sheets.documentaries.find(_ => _.docName === linkedDocName);
-            return linkedDocMetadata;
+            if (linkedDocName && linkedDocMetadata) {
+              return linkedDocMetadata;
+            } else {
+              return undefined;
+            }
           }).filter((doc) => {
             return doc !== undefined;
           });

--- a/src/js/lib/sheetData.js
+++ b/src/js/lib/sheetData.js
@@ -138,6 +138,10 @@ class DocumentaryMetadata {
     return this.comingSoon[0];
   }
 
+  get linkedDocs() {
+    return this._docData.linkedDocs;
+  }
+
   get onwardJourneyLinks() {
     return ['One', 'Two', 'Three', 'Four'].reduce((links, i) => {
       links.push({ position: i, jsonUrl: this.getField(`jsonSnap${i}`) });

--- a/src/js/lib/sheetNameFromShortId.js
+++ b/src/js/lib/sheetNameFromShortId.js
@@ -3,12 +3,11 @@ const DEFAULT_DOC = 'a-childhood-on-fire';
 export default function sheetNameFromShortId(docsArray, shortUrl) {
     const map = new Map(docsArray);
     const docName = map.get(shortUrl);
-    console.log(DEFAULT_DOC)
 
-    // uncomment and just return DEFAULT_DOC
-    // to test other docs locally
-    // return DEFAULT_DOC;
-
-    return docName ? docName : DEFAULT_DOC;
+    if (window.location.hostname == 'localhost') {
+        return DEFAULT_DOC;
+    } else {
+        return docName ? docName : DEFAULT_DOC;
+    }
 
 }

--- a/src/js/lib/sheetURL.js
+++ b/src/js/lib/sheetURL.js
@@ -1,4 +1,9 @@
-export default function sheetURL(sheetID, type='docsdata') {
-    var protocol = window.location.protocol === 'file:' ? 'https://' : '//';
-    return `${protocol}interactive.guim.co.uk/${type}/${sheetID}.json`;
+export default function sheetURL(sheetID) {
+  var protocol = window.location.protocol === 'file:' ? 'https://' : '//';
+  if (window.location.hostname == 'localhost') {
+    var type = 'docsdata-test';
+  } else {
+    var type = 'docsdata';
+  }
+  return `${protocol}interactive.guim.co.uk/${type}/${sheetID}.json`;
 }

--- a/src/js/lib/sheetURL.js
+++ b/src/js/lib/sheetURL.js
@@ -1,9 +1,5 @@
 export default function sheetURL(sheetID) {
-  var protocol = window.location.protocol === 'file:' ? 'https://' : '//';
-  if (window.location.hostname == 'localhost') {
-    var type = 'docsdata-test';
-  } else {
-    var type = 'docsdata';
-  }
-  return `${protocol}interactive.guim.co.uk/${type}/${sheetID}.json`;
+    var protocol = window.location.protocol === 'file:' ? 'https://' : '//';
+    var type = (window.location.hostname == 'localhost' ? 'docsdata-test' : 'docsdata');
+    return `${protocol}interactive.guim.co.uk/${type}/${sheetID}.json`;
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -128,11 +128,13 @@ export function init(el, context, config) {
         el.parentNode.replaceChild(builder, el);
 
         if (docData.linkedDocs.length > 0) {
+            // use linkedDocs data to inject onward journey elements
             docData.linkedDocs.forEach((linkedDoc, i) => {
                 const el = builder.querySelector(`section#more-documentaries .fc-slice__item:nth-child(${++i}) .nextSnap`);
                 el.innerHTML = `<div class="doc-card"><img class="doc-card__poster" src="${linkedDoc.posterImage}"><div class="doc-card__meta"><p class="doc-card__description">${linkedDoc.logline}</p><a class="doc-card__link" href="${linkedDoc.fullLink}"></a></div></div>`;
             });
         } else {
+            // Use legacy doc-cards snaps
             docData.onwardJourneyLinks.forEach(snapLink => {
                 reqwest({
                     'url': snapLink.jsonUrl,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -127,17 +127,24 @@ export function init(el, context, config) {
 
         el.parentNode.replaceChild(builder, el);
 
-        docData.onwardJourneyLinks.forEach(snapLink => {
-            reqwest({
-                'url': snapLink.jsonUrl,
-                'type': 'json',
-                'crossOrigin': true,
-                'success': snapJSON => {
-                    const el = builder.querySelector(`section#more-documentaries .nextSnap${snapLink.position}`);
-                    el.innerHTML = snapJSON.html;
-                }
+        if (docData.linkedDocs.length > 0) {
+            docData.linkedDocs.forEach((linkedDoc, i) => {
+                const el = builder.querySelector(`section#more-documentaries .fc-slice__item:nth-child(${++i}) .nextSnap`);
+                el.innerHTML = `<div class="doc-card"><img class="doc-card__poster" src="${linkedDoc.posterImage}"><div class="doc-card__meta"><p class="doc-card__description">${linkedDoc.logline}</p><a class="doc-card__link" href="${linkedDoc.fullLink}"></a></div></div>`;
             });
-        });
+        } else {
+            docData.onwardJourneyLinks.forEach(snapLink => {
+                reqwest({
+                    'url': snapLink.jsonUrl,
+                    'type': 'json',
+                    'crossOrigin': true,
+                    'success': snapJSON => {
+                        const el = builder.querySelector(`section#more-documentaries .nextSnap${snapLink.position}`);
+                        el.innerHTML = snapJSON.html;
+                    }
+                });
+            });
+        }
 
         const autoplayReferrers = [
             /^https?:\/\/localhost:8000/,

--- a/src/js/text/main.html
+++ b/src/js/text/main.html
@@ -60,16 +60,16 @@
                 <div class="fc-slice-wrapper">
                     <ul class="u-unstyled l-row  l-row--cols-4 fc-slice fc-slice--q-q-q-q">
                         <li class="fc-slice__item l-row__item l-row__item--span-1 u-faux-block-link">
-                            <div class="nextSnapOne facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-1"></div>
+                            <div class="nextSnap nextSnapOne facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-1"></div>
                         </li>
                         <li class="fc-slice__item l-row__item l-row__item--span-1 u-faux-block-link">
-                            <div class="nextSnapTwo facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-2"></div>
+                            <div class="nextSnap nextSnapTwo facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-2"></div>
                         </li>
                         <li class="fc-slice__item l-row__item l-row__item--span-1 u-faux-block-link">
-                            <div class="nextSnapThree facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-3"></div>
+                            <div class="nextSnap nextSnapThree facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-3"></div>
                         </li>
                         <li class="fc-slice__item l-row__item l-row__item--span-1 u-faux-block-link">
-                            <div class="nextSnapFour facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-4"></div>
+                            <div class="nextSnap nextSnapFour facia-snap facia-snap--default facia-snap-embed fc-item fc-item--has-image fc-item--has-metadata fc-item--is-commentable fc-item--is-media-link fc-item--video js-fc-item js-snap tone-media--item fc-item--list-media-mobile fc-item--standard-tablet facia-snap-point--small" data-link-name="docs interactive | card-4"></div>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
This removes dependency on [doc-cards](https://github.com/guardian/doc-cards) for onward journeys by pulling in a poster image, logline and link from the documentaries sheet instead.