### PR TITLE
fix(a11y): add title to iframe

### DIFF
--- a/src/js/text/main.html
+++ b/src/js/text/main.html
@@ -114,7 +114,7 @@
             </div>
             <div class='coming-soon__newsletter'>
                 <p>We release a new documentary monthly. Would you like a reminder email?</p>
-                <iframe height="131px" data-form-success-headline="Thank you" data-form-success-desc="We will send you reminders about forthcoming documentaries." scrolling="no" frameborder="0" class="email-form__iframe email-form__iframe iframed--overflow-hidden email-sub__iframe email-sub__iframe--end-article js-email-sub__iframe js-email-sub__iframe--article"></iframe>
+                <iframe height="131px" title="Documentary sign up form" data-form-success-headline="Thank you" data-form-success-desc="We will send you reminders about forthcoming documentaries." scrolling="no" frameborder="0" class="email-form__iframe email-form__iframe iframed--overflow-hidden email-sub__iframe email-sub__iframe--end-article js-email-sub__iframe js-email-sub__iframe--article"></iframe>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What does this change?

Add the title attribute to the sign up iframe, as it an accessibility issue.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

🤷 

## How can we measure success?

Resolves: https://github.com/guardian/dotcom-rendering/issues/4454

## Have we considered potential risks?

N/A

## Images

N/A

## Accessibility

-   [X] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader) By DAC
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
